### PR TITLE
Batch add members

### DIFF
--- a/src/Core/ExchangeConnector.cs
+++ b/src/Core/ExchangeConnector.cs
@@ -114,7 +114,7 @@ namespace Hummingbird.Core
         /// <param name="additionalParam">List of additional parameters needed for a request.</param>
         /// <returns></returns>
         public IExchangeResponse PerformExchangeRequest(UserCredentials credentials, string exchangeUrl, string param,
-            ExchangeRequestType requestType, List<string> additionalParam = null)
+            ExchangeRequestType requestType, IEnumerable<string> additionalParam = null)
         {
             var postContent = string.Empty;
             Type type = null;

--- a/src/Hummingbird.sln
+++ b/src/Hummingbird.sln
@@ -1,0 +1,26 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hummingbird", "Hummingbird.csproj", "{B5CD7BDA-49BF-42EC-8AB0-FF4C7349F1D4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B5CD7BDA-49BF-42EC-8AB0-FF4C7349F1D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5CD7BDA-49BF-42EC-8AB0-FF4C7349F1D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5CD7BDA-49BF-42EC-8AB0-FF4C7349F1D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5CD7BDA-49BF-42EC-8AB0-FF4C7349F1D4}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		EnterpriseLibraryConfigurationToolBinariesPathV6 = packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45;packages\EnterpriseLibrary.Logging.6.0.1304.0\lib\NET45
+		EnterpriseLibraryConfigurationToolBinariesPath = packages\Unity.2.1.505.0\lib\NET35;packages\Unity.Interception.2.1.505.0\lib\NET35;packages\EnterpriseLibrary.Common.5.0.505.0\lib\NET35;packages\EnterpriseLibrary.Logging.5.0.505.1\lib\NET35
+	EndGlobalSection
+EndGlobal

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,7 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
   <package id="EnterpriseLibrary.Common" version="6.0.1304.0" targetFramework="net45" />
   <package id="EnterpriseLibrary.Logging" version="6.0.1304.0" targetFramework="net45" />
   <package id="Microsoft.Exchange.WebServices" version="2.2" targetFramework="net45" />
-  <package id="ModernUI.WPF" version="1.0.6" targetFramework="net45" />
+  <package id="ModernUI.WPF" version="1.0.9" targetFramework="net45" />
+  <package id="Unity" version="4.0.1" targetFramework="net45" />
+  <package id="Unity.Interception" version="4.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
In testing, we found that we were unable to add more than around 225
members in a single shot. Specifically, we tried adding 250 members (and
larger batch sizes) and the server operation appeared to be successful.
It returned 200 OK with "noerror". However, no members were actually
added to the group.

As a workaround, we'll make several EWS calls to add members in batches
of 225. This number can be changed by adjusting the constant in
BulkAddMain.
