### PR TITLE
Support member addition for Large Dls and creating group on behalf of others.

### DIFF
--- a/src/Core/AppSetup.cs
+++ b/src/Core/AppSetup.cs
@@ -3,8 +3,9 @@
     public static class AppSetup
     {
         // Active Directory lookup settings
-        public const string ActiveLookupDomain = "REDMOND";
-        public const string ActiveDomainControllerPrefix = "corp";
+        // While publishing an EXE for use by Microsoft, this value has to be ActiveLookupDomain:REDMOND ActiveDomainControllerPrefix:corp
+        public const string ActiveLookupDomain = "CHANGE_DOMAIN";
+        public const string ActiveDomainControllerPrefix = "CHANGE_CONTROLLER_PREFIX";
 
         // Settings location
         public const string CredentialContainerName = "container";

--- a/src/Core/AppSetup.cs
+++ b/src/Core/AppSetup.cs
@@ -3,7 +3,7 @@
     public static class AppSetup
     {
         // Active Directory lookup settings
-        // While publishing an EXE for use by Microsoft, this value has to be ActiveLookupDomain:REDMOND ActiveDomainControllerPrefix:corp
+        // Ex: if the Domain is abc.xyz.contoso.com then the ActiveLookupDomain is abc and ActiveDomainControllerPrefix is xyz
         public const string ActiveLookupDomain = "CHANGE_DOMAIN";
         public const string ActiveDomainControllerPrefix = "CHANGE_CONTROLLER_PREFIX";
 

--- a/src/Core/Common/FileSystemOperator.cs
+++ b/src/Core/Common/FileSystemOperator.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Serialization;
@@ -31,7 +30,7 @@ namespace Hummingbird.Core.Common
             {
                 var directory = Directory.CreateDirectory(AppPath);
 
-                var serializer = new XmlSerializer(typeof(DistributionList));
+                var serializer = new XmlSerializer(typeof (DistributionList));
                 path = Path.Combine(directory.FullName, distributionList.Name + ".xmldl");
 
                 using (var writer = new StreamWriter(path))
@@ -61,8 +60,10 @@ namespace Hummingbird.Core.Common
         /// Stores the DL invalid members info in a local file.
         /// </summary>
         /// <param name="distributionList">Existing distribution list model.</param>
+        /// <param name="actionName">Name of the flow attempting to write a failure list</param>
+        /// <param name="errorDetails">Add Members details to be written</param>
         /// <returns></returns>
-        internal string StoreDistributionListFailures(DistributionList distributionList, string action, AddMembersErrorDetails error)
+        internal string StoreDistributionListFailures(DistributionList distributionList, string actionName, AddMembersErrorDetails errorDetails)
         {
             string path;
 
@@ -71,11 +72,11 @@ namespace Hummingbird.Core.Common
                 var directory = Directory.CreateDirectory(AppPath);
 
                 var serializer = new XmlSerializer(typeof(AddMembersErrorDetails));
-                path = Path.Combine(directory.FullName, distributionList.Name + "_" + action + "_Failures.xmldl");
+                path = Path.Combine(directory.FullName, distributionList.Name + "_" + actionName + "_Failures.xmldl");
 
                 using (var writer = new StreamWriter(path))
                 {
-                    serializer.Serialize(writer, error);
+                    serializer.Serialize(writer, errorDetails);
                 }
 
                 LoggingViewModel.Instance.Logger.Write(string.Concat("StoreDistributionListInvalidMembers:OK ", path,
@@ -107,8 +108,8 @@ namespace Hummingbird.Core.Common
             {
                 using (var reader = new StreamReader(filePath))
                 {
-                    var serializer = new XmlSerializer(typeof(DistributionList));
-                    var distributionList = (DistributionList)serializer.Deserialize(reader);
+                    var serializer = new XmlSerializer(typeof (DistributionList));
+                    var distributionList = (DistributionList) serializer.Deserialize(reader);
 
                     return distributionList;
                 }

--- a/src/Core/Common/FileSystemOperator.cs
+++ b/src/Core/Common/FileSystemOperator.cs
@@ -48,7 +48,7 @@ namespace Hummingbird.Core.Common
                     exception.Message, Environment.NewLine,
                     exception.StackTrace, Environment.NewLine, string.Join(",", distributionList.Members.ToArray()),
                     Environment.NewLine,
-                    distributionList.Owner));
+                    distributionList.Name));
 
                 path = string.Empty;
             }

--- a/src/Core/Common/FileSystemOperator.cs
+++ b/src/Core/Common/FileSystemOperator.cs
@@ -89,7 +89,7 @@ namespace Hummingbird.Core.Common
                     exception.Message, Environment.NewLine,
                     exception.StackTrace,
                     Environment.NewLine,
-                    distributionList.Owner));
+                    distributionList.Name));
 
                 path = string.Empty;
             }

--- a/src/Core/ExchangeConnector.cs
+++ b/src/Core/ExchangeConnector.cs
@@ -25,6 +25,7 @@ namespace Hummingbird.Core
         /// </summary>
         /// <param name="dl">Distribution list name (alias) without the domain.</param>
         /// <param name="credentials">User credentials for service access.</param>
+        /// <param name="isValidDl">Indicates if there exists a DL with the alias.</param>
         /// <returns></returns>
         public string GetExternalDistributionListOwner(string dl, UserCredentials credentials, out bool isValidDl)
         {
@@ -132,7 +133,7 @@ namespace Hummingbird.Core
             Type type = null;
 
             var authHeaderContent = GetBasicAuthFormat(credentials);
-            var request = (HttpWebRequest)WebRequest.Create(exchangeUrl);
+            var request = (HttpWebRequest) WebRequest.Create(exchangeUrl);
             request.Method = WebRequestMethods.Http.Post;
             request.Headers.Add(HttpRequestHeader.Authorization, string.Concat("Basic ", authHeaderContent));
             request.ContentType = "text/xml";
@@ -144,7 +145,7 @@ namespace Hummingbird.Core
                         LoggingViewModel.Instance.Logger.Write(string.Concat("ExchangeConnector:ValidateAlias ", param));
 
                         postContent = Resources.AliasValidationPOST.Replace(AppSetup.GroupIdFiller, param);
-                        type = typeof(AliasValidationEnvelope);
+                        type = typeof (AliasValidationEnvelope);
                         break;
                     }
                 case ExchangeRequestType.CreateGroup:
@@ -156,7 +157,7 @@ namespace Hummingbird.Core
                         {
                             postContent = postContent.Replace(AppSetup.OwnerSmtpFiller, additionalParam.First());
                         }
-                        type = typeof(GroupCreationEnvelope);
+                        type = typeof (GroupCreationEnvelope);
                         break;
                     }
                 case ExchangeRequestType.GetUnifiedGroupDetails:
@@ -164,7 +165,7 @@ namespace Hummingbird.Core
                         LoggingViewModel.Instance.Logger.Write(string.Concat("ExchangeConnector:GetGroupDetails ", param));
 
                         postContent = Resources.GetUnifiedGroupsPOST.Replace(AppSetup.GroupSmtpFiller, param);
-                        type = typeof(GetUnifiedGroupEnvelope);
+                        type = typeof (GetUnifiedGroupEnvelope);
 
                         break;
                     }
@@ -187,8 +188,8 @@ namespace Hummingbird.Core
                             {
                                 using (var reader = new StreamReader(addMemberEnvelopeStream))
                                 {
-                                    var serializer = new XmlSerializer(typeof(AddMemberEnvelope));
-                                    var deserializedContent = (AddMemberEnvelope)serializer.Deserialize(reader);
+                                    var serializer = new XmlSerializer(typeof (AddMemberEnvelope));
+                                    var deserializedContent = (AddMemberEnvelope) serializer.Deserialize(reader);
 
                                     deserializedContent.Body.SetUnifiedGroupMembershipState.Members =
                                         new List<string>(additionalParam);
@@ -210,7 +211,7 @@ namespace Hummingbird.Core
                                             LoggingViewModel.Instance.Logger.Write(
                                                 string.Concat("ExchangeConnector:AddMemberPostContent ", postContent));
 
-                                            type = typeof(SetMemberEnvelope);
+                                            type = typeof (SetMemberEnvelope);
                                         }
                                     }
                                 }
@@ -235,7 +236,7 @@ namespace Hummingbird.Core
 
             try
             {
-                var response = (HttpWebResponse)request.GetResponse();
+                var response = (HttpWebResponse) request.GetResponse();
                 if (response.StatusCode == HttpStatusCode.OK)
                 {
                     using (var responseStream = response.GetResponseStream())
@@ -244,7 +245,7 @@ namespace Hummingbird.Core
                         {
                             var serializer = new XmlSerializer(type);
 
-                            var translatedResponse = (IExchangeResponse)serializer.Deserialize(reader);
+                            var translatedResponse = (IExchangeResponse) serializer.Deserialize(reader);
                             return translatedResponse;
                         }
                     }

--- a/src/Core/ExchangeConnector.cs
+++ b/src/Core/ExchangeConnector.cs
@@ -136,6 +136,7 @@ namespace Hummingbird.Core
             var request = (HttpWebRequest) WebRequest.Create(exchangeUrl);
             request.Method = WebRequestMethods.Http.Post;
             request.Headers.Add(HttpRequestHeader.Authorization, string.Concat("Basic ", authHeaderContent));
+            request.Headers.Add(HttpRequestHeader.UserAgent, "Humming Bird");
             request.ContentType = "text/xml";
 
             switch (requestType)

--- a/src/Core/ExchangeConnector.cs
+++ b/src/Core/ExchangeConnector.cs
@@ -79,11 +79,17 @@ namespace Hummingbird.Core
 
                         plPileLine.Stop();
                     }
+                    else if (rsResultsresults.Count == 0)
+                    {
+                        LoggingViewModel.Instance.Logger.Write(string.Concat("GetExternalDistributionListOwner ",
+                            Environment.NewLine,
+                            "DistributionListNotFound", Environment.NewLine, dl));
+                    }
                     else
                     {
                         LoggingViewModel.Instance.Logger.Write(string.Concat("GetExternalDistributionListOwner ",
                             Environment.NewLine,
-                            "INVALID DL", Environment.NewLine, dl));
+                            "NonUniqueDistributionListFound", Environment.NewLine, dl));
                     }
                 }
 
@@ -136,7 +142,7 @@ namespace Hummingbird.Core
             var request = (HttpWebRequest) WebRequest.Create(exchangeUrl);
             request.Method = WebRequestMethods.Http.Post;
             request.Headers.Add(HttpRequestHeader.Authorization, string.Concat("Basic ", authHeaderContent));
-            request.Headers.Add(HttpRequestHeader.UserAgent, "Humming Bird");
+            request.UserAgent = "Hummingbird";
             request.ContentType = "text/xml";
 
             switch (requestType)
@@ -154,9 +160,10 @@ namespace Hummingbird.Core
                         LoggingViewModel.Instance.Logger.Write(string.Concat("ExchangeConnector:CreateGroup ", param));
 
                         postContent = Resources.GroupCreationPOST.Replace(AppSetup.GroupIdFiller, param);
-                        if (additionalParam != null && additionalParam.Count() == 1)
+                        var additionalParamList = additionalParam.ToList();
+                        if (additionalParam != null && additionalParamList.Count == 1)
                         {
-                            postContent = postContent.Replace(AppSetup.OwnerSmtpFiller, additionalParam.First());
+                            postContent = postContent.Replace(AppSetup.OwnerSmtpFiller, additionalParamList[0]);
                         }
                         type = typeof (GroupCreationEnvelope);
                         break;

--- a/src/Core/ExchangeConnector.cs
+++ b/src/Core/ExchangeConnector.cs
@@ -160,8 +160,8 @@ namespace Hummingbird.Core
                         LoggingViewModel.Instance.Logger.Write(string.Concat("ExchangeConnector:CreateGroup ", param));
 
                         postContent = Resources.GroupCreationPOST.Replace(AppSetup.GroupIdFiller, param);
-                        var additionalParamList = additionalParam.ToList();
-                        if (additionalParam != null && additionalParamList.Count == 1)
+                        var additionalParamList = additionalParam != null ? additionalParam.ToList() : null;
+                        if (additionalParamList != null && additionalParamList.Count == 1)
                         {
                             postContent = postContent.Replace(AppSetup.OwnerSmtpFiller, additionalParamList[0]);
                         }

--- a/src/Core/Internal/ActiveDirectoryConnector.cs
+++ b/src/Core/Internal/ActiveDirectoryConnector.cs
@@ -47,7 +47,7 @@ namespace Hummingbird.Core.Internal
                         LoggingViewModel.Instance.Logger.Write(string.Concat("AD:DL ", distributionList.DisplayName, "\n",
                             distributionList.UserPrincipalName, "\n", distributionList.Guid));
 
-                        var entry = (DirectoryEntry)distributionList.GetUnderlyingObject();
+                        var entry = (DirectoryEntry) distributionList.GetUnderlyingObject();
                         var propertyValueCollection = entry.Properties["managedBy"];
                         var userIdentity = propertyValueCollection.Value.ToString();
 

--- a/src/Core/Internal/ActiveDirectoryConnector.cs
+++ b/src/Core/Internal/ActiveDirectoryConnector.cs
@@ -70,7 +70,7 @@ namespace Hummingbird.Core.Internal
                     {
                         LoggingViewModel.Instance.Logger.Write(string.Concat("GetDistributionListOwner",
                             Environment.NewLine,
-                            "INVALID DL", Environment.NewLine, alias));
+                            "DistributionListNotFound", Environment.NewLine, alias));
                     }
                 }
                 catch (Exception ex)

--- a/src/Hummingbird.csproj
+++ b/src/Hummingbird.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -53,10 +53,10 @@
     <ApplicationIcon>1427799497_61706.ico</ApplicationIcon>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestCertificateThumbprint>33EFE949EFD5D953A3296B5F53ED86FC253334BB</ManifestCertificateThumbprint>
+    <ManifestCertificateThumbprint>81C1B429C2BCC984AE145A1F527A9111DD32C97F</ManifestCertificateThumbprint>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestKeyFile>Hummingbird_1_TemporaryKey.pfx</ManifestKeyFile>
+    <ManifestKeyFile>Hummingbird_TemporaryKey.pfx</ManifestKeyFile>
   </PropertyGroup>
   <PropertyGroup>
     <GenerateManifests>true</GenerateManifests>
@@ -64,49 +64,22 @@
   <PropertyGroup>
     <SignManifests>true</SignManifests>
   </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
-  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FirstFloor.ModernUI, Version=1.0.9.0, Culture=neutral, PublicKeyToken=bc9b0c37bf06c6a9, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\CorextCache\ModernUI.WPF.1.0.9\lib\net45\FirstFloor.ModernUI.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FirstFloor.ModernUI">
+      <HintPath>..\packages\ModernUI.WPF.1.0.6\lib\net45\FirstFloor.ModernUI.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Exchange.WebServices, Version=15.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\CorextCache\Microsoft.Exchange.WebServices.2.2\lib\40\Microsoft.Exchange.WebServices.dll</HintPath>
       <Private>True</Private>
+      <HintPath>..\packages\Microsoft.Exchange.WebServices.2.2\lib\40\Microsoft.Exchange.WebServices.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Exchange.WebServices.Auth, Version=15.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\CorextCache\Microsoft.Exchange.WebServices.2.2\lib\40\Microsoft.Exchange.WebServices.Auth.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Exchange.WebServices.Auth">
+      <HintPath>..\packages\Microsoft.Exchange.WebServices.2.2\lib\40\Microsoft.Exchange.WebServices.Auth.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Practices.EnterpriseLibrary.Common, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\CorextCache\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.Common">
+      <HintPath>..\packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Practices.EnterpriseLibrary.Logging, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\CorextCache\EnterpriseLibrary.Logging.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Logging.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\CorextCache\CommonServiceLocator.1.0\lib\NET35\Microsoft.Practices.ServiceLocation.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Practices.Unity, Version=2.1.505.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\CorextCache\Unity.2.1.505.0\lib\NET35\Microsoft.Practices.Unity.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Practices.Unity.Configuration, Version=2.1.505.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\CorextCache\Unity.2.1.505.0\lib\NET35\Microsoft.Practices.Unity.Configuration.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Practices.Unity.Interception, Version=2.1.505.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\CorextCache\Unity.Interception.2.1.505.0\lib\NET35\Microsoft.Practices.Unity.Interception.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Practices.Unity.Interception.Configuration, Version=2.1.505.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\CorextCache\Unity.Interception.2.1.505.0\lib\NET35\Microsoft.Practices.Unity.Interception.Configuration.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.Logging">
+      <HintPath>..\packages\EnterpriseLibrary.Logging.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Logging.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -244,7 +217,6 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <None Include="Hummingbird_1_TemporaryKey.pfx" />
     <None Include="Hummingbird_TemporaryKey.pfx" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/src/Hummingbird.csproj
+++ b/src/Hummingbird.csproj
@@ -53,10 +53,10 @@
     <ApplicationIcon>1427799497_61706.ico</ApplicationIcon>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestCertificateThumbprint>81C1B429C2BCC984AE145A1F527A9111DD32C97F</ManifestCertificateThumbprint>
+    <ManifestCertificateThumbprint>33EFE949EFD5D953A3296B5F53ED86FC253334BB</ManifestCertificateThumbprint>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestKeyFile>Hummingbird_TemporaryKey.pfx</ManifestKeyFile>
+    <ManifestKeyFile>Hummingbird_1_TemporaryKey.pfx</ManifestKeyFile>
   </PropertyGroup>
   <PropertyGroup>
     <GenerateManifests>true</GenerateManifests>
@@ -64,22 +64,49 @@
   <PropertyGroup>
     <SignManifests>true</SignManifests>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FirstFloor.ModernUI">
-      <HintPath>..\packages\ModernUI.WPF.1.0.6\lib\net45\FirstFloor.ModernUI.dll</HintPath>
+    <Reference Include="FirstFloor.ModernUI, Version=1.0.9.0, Culture=neutral, PublicKeyToken=bc9b0c37bf06c6a9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\CorextCache\ModernUI.WPF.1.0.9\lib\net45\FirstFloor.ModernUI.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Exchange.WebServices, Version=15.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\CorextCache\Microsoft.Exchange.WebServices.2.2\lib\40\Microsoft.Exchange.WebServices.dll</HintPath>
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.Exchange.WebServices.2.2\lib\40\Microsoft.Exchange.WebServices.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Exchange.WebServices.Auth">
-      <HintPath>..\packages\Microsoft.Exchange.WebServices.2.2\lib\40\Microsoft.Exchange.WebServices.Auth.dll</HintPath>
+    <Reference Include="Microsoft.Exchange.WebServices.Auth, Version=15.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\CorextCache\Microsoft.Exchange.WebServices.2.2\lib\40\Microsoft.Exchange.WebServices.Auth.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Practices.EnterpriseLibrary.Common">
-      <HintPath>..\packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Common.dll</HintPath>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.Common, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\CorextCache\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Common.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Practices.EnterpriseLibrary.Logging">
-      <HintPath>..\packages\EnterpriseLibrary.Logging.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Logging.dll</HintPath>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.Logging, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\CorextCache\EnterpriseLibrary.Logging.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\CorextCache\CommonServiceLocator.1.0\lib\NET35\Microsoft.Practices.ServiceLocation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity, Version=2.1.505.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\CorextCache\Unity.2.1.505.0\lib\NET35\Microsoft.Practices.Unity.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity.Configuration, Version=2.1.505.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\CorextCache\Unity.2.1.505.0\lib\NET35\Microsoft.Practices.Unity.Configuration.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity.Interception, Version=2.1.505.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\CorextCache\Unity.Interception.2.1.505.0\lib\NET35\Microsoft.Practices.Unity.Interception.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity.Interception.Configuration, Version=2.1.505.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\CorextCache\Unity.Interception.2.1.505.0\lib\NET35\Microsoft.Practices.Unity.Interception.Configuration.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -217,6 +244,7 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <None Include="Hummingbird_1_TemporaryKey.pfx" />
     <None Include="Hummingbird_TemporaryKey.pfx" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/src/Hummingbird.sln
+++ b/src/Hummingbird.sln
@@ -1,4 +1,5 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1

--- a/src/Hummingbird.sln
+++ b/src/Hummingbird.sln
@@ -1,7 +1,6 @@
-﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hummingbird", "Hummingbird.csproj", "{B5CD7BDA-49BF-42EC-8AB0-FF4C7349F1D4}"
 EndProject
@@ -11,8 +10,8 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B5CD7BDA-49BF-42EC-8AB0-FF4C7349F1D4}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{B5CD7BDA-49BF-42EC-8AB0-FF4C7349F1D4}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{B5CD7BDA-49BF-42EC-8AB0-FF4C7349F1D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5CD7BDA-49BF-42EC-8AB0-FF4C7349F1D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B5CD7BDA-49BF-42EC-8AB0-FF4C7349F1D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B5CD7BDA-49BF-42EC-8AB0-FF4C7349F1D4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
@@ -20,7 +19,7 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		EnterpriseLibraryConfigurationToolBinariesPath = packages\Unity.2.1.505.0\lib\NET35;packages\Unity.Interception.2.1.505.0\lib\NET35;packages\EnterpriseLibrary.Common.5.0.505.0\lib\NET35;packages\EnterpriseLibrary.Logging.5.0.505.1\lib\NET35;;5.0\lib\NET35;05.1\lib\NET35
-		EnterpriseLibraryConfigurationToolBinariesPathV6 = packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45;packages\EnterpriseLibrary.Logging.6.0.1304.0\lib\NET45;304.0\lib\NET45;04.0\lib\NET45
+		EnterpriseLibraryConfigurationToolBinariesPathV6 = packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45;packages\EnterpriseLibrary.Logging.6.0.1304.0\lib\NET45
+		EnterpriseLibraryConfigurationToolBinariesPath = packages\Unity.2.1.505.0\lib\NET35;packages\Unity.Interception.2.1.505.0\lib\NET35;packages\EnterpriseLibrary.Common.5.0.505.0\lib\NET35;packages\EnterpriseLibrary.Logging.5.0.505.1\lib\NET35
 	EndGlobalSection
 EndGlobal

--- a/src/Hummingbird.sln
+++ b/src/Hummingbird.sln
@@ -1,0 +1,26 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hummingbird", "Hummingbird.csproj", "{B5CD7BDA-49BF-42EC-8AB0-FF4C7349F1D4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B5CD7BDA-49BF-42EC-8AB0-FF4C7349F1D4}.Debug|Any CPU.ActiveCfg = Release|Any CPU
+		{B5CD7BDA-49BF-42EC-8AB0-FF4C7349F1D4}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{B5CD7BDA-49BF-42EC-8AB0-FF4C7349F1D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5CD7BDA-49BF-42EC-8AB0-FF4C7349F1D4}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		EnterpriseLibraryConfigurationToolBinariesPath = packages\Unity.2.1.505.0\lib\NET35;packages\Unity.Interception.2.1.505.0\lib\NET35;packages\EnterpriseLibrary.Common.5.0.505.0\lib\NET35;packages\EnterpriseLibrary.Logging.5.0.505.1\lib\NET35;;5.0\lib\NET35;05.1\lib\NET35
+		EnterpriseLibraryConfigurationToolBinariesPathV6 = packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45;packages\EnterpriseLibrary.Logging.6.0.1304.0\lib\NET45;304.0\lib\NET45;04.0\lib\NET45
+	EndGlobalSection
+EndGlobal

--- a/src/Models/AddMembersErrorDetails.cs
+++ b/src/Models/AddMembersErrorDetails.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace Hummingbird.Models
 {

--- a/src/Models/EnvelopeAtoms/SetUnifiedGroupMembership.cs
+++ b/src/Models/EnvelopeAtoms/SetUnifiedGroupMembership.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Xml.Serialization;
 
 namespace Hummingbird.Models.EnvelopeAtoms
@@ -15,8 +14,7 @@ namespace Hummingbird.Models.EnvelopeAtoms
 
         [XmlAttributeAttribute()]
         public string ResponseClass { get; set; }
-        /// <remarks/>
-        /// 
+
         [System.Xml.Serialization.XmlArrayItemAttribute("Member", IsNullable = true)]
         public List<string> InvalidMembers { get; set; }
 

--- a/src/Pages/AccountPageMain.xaml
+++ b/src/Pages/AccountPageMain.xaml
@@ -21,7 +21,9 @@
                 <TextBlock Style="{StaticResource Title}" Text="url"></TextBlock>
                 <TextBox Text="{Binding ServerUrl,Mode=TwoWay}" Width="200" HorizontalAlignment="Left" Margin="0,0,0,8"/>
                 <TextBlock Style="{StaticResource Title}" Text="target"></TextBlock>
+                <!-- Internal: Uses AD to fetch the DL details and is meant to be used by MSFT users -->
                 <RadioButton Content="Internal" IsChecked="{Binding IsInternal,Mode=TwoWay}" Margin="0,4,0,0"></RadioButton>
+                <!-- External: Uses Cmdlets to fetch the DL details and is meant to be used by any tenant admin -->
                 <RadioButton Content="External" IsChecked="{Binding IsInternal,Mode=TwoWay,Converter={StaticResource InverseBooleanConverter}}" Margin="0,4,0,0"></RadioButton>
                 <Button Content="save server settings" Width="180" HorizontalAlignment="Left" Margin="0,12,0,0" x:Name="BtnSaveSettings" Click="btnSaveSettings_Click"></Button>
             </StackPanel>

--- a/src/Pages/AccountPageMain.xaml
+++ b/src/Pages/AccountPageMain.xaml
@@ -21,7 +21,7 @@
                 <TextBlock Style="{StaticResource Title}" Text="url"></TextBlock>
                 <TextBox Text="{Binding ServerUrl,Mode=TwoWay}" Width="200" HorizontalAlignment="Left" Margin="0,0,0,8"/>
                 <TextBlock Style="{StaticResource Title}" Text="target"></TextBlock>
-                <!-- Internal: Uses AD to fetch the DL details and is meant to be used by MSFT users -->
+                <!-- Internal: Uses AD to fetch the DL details and is meant to be used by users whose have access to DL. Domain Controller settings needs to be updated in this case. -->
                 <RadioButton Content="Internal" IsChecked="{Binding IsInternal,Mode=TwoWay}" Margin="0,4,0,0"></RadioButton>
                 <!-- External: Uses Cmdlets to fetch the DL details and is meant to be used by any tenant admin -->
                 <RadioButton Content="External" IsChecked="{Binding IsInternal,Mode=TwoWay,Converter={StaticResource InverseBooleanConverter}}" Margin="0,4,0,0"></RadioButton>

--- a/src/Pages/AccountPageMain.xaml
+++ b/src/Pages/AccountPageMain.xaml
@@ -21,7 +21,7 @@
                 <TextBlock Style="{StaticResource Title}" Text="url"></TextBlock>
                 <TextBox Text="{Binding ServerUrl,Mode=TwoWay}" Width="200" HorizontalAlignment="Left" Margin="0,0,0,8"/>
                 <TextBlock Style="{StaticResource Title}" Text="target"></TextBlock>
-                <!-- Internal: Uses AD to fetch the DL details and is meant to be used by users whose have access to DL. Domain Controller settings needs to be updated in this case. -->
+                <!-- Internal: Uses AD to fetch the DL details and is meant to be used by users whose have access to DL. Active Directory lookup settings needs to be updated in this case in AppSetup.cs -->
                 <RadioButton Content="Internal" IsChecked="{Binding IsInternal,Mode=TwoWay}" Margin="0,4,0,0"></RadioButton>
                 <!-- External: Uses Cmdlets to fetch the DL details and is meant to be used by any tenant admin -->
                 <RadioButton Content="External" IsChecked="{Binding IsInternal,Mode=TwoWay,Converter={StaticResource InverseBooleanConverter}}" Margin="0,4,0,0"></RadioButton>

--- a/src/Pages/BulkAddMain.xaml.cs
+++ b/src/Pages/BulkAddMain.xaml.cs
@@ -80,7 +80,7 @@ namespace Hummingbird.Pages
 
                     if (addMembersResults.All(x => x.StatusCode.ToLower() == "noerror"))
                     {
-                        string message = string.Format("Bulk add complete! Added {0} members.", totalMembersCount);
+                        string message = string.Format("The bulk add was successful. {0} members were added.", totalMembersCount);
 
                         ModernDialog.ShowMessage(
                             message,
@@ -134,7 +134,7 @@ namespace Hummingbird.Pages
                         {
                             var result =
                                 ModernDialog.ShowMessage(
-                                    "Failures list is created. Open Windows Explorer for its location?",
+                                    "A list of failures was created. Do you want to open File Explorer to find its location?",
                                     "Hummingbird", MessageBoxButton.YesNo);
 
                             if (result == MessageBoxResult.Yes)
@@ -149,7 +149,7 @@ namespace Hummingbird.Pages
                 catch (Exception)
                 {
                     ModernDialog.ShowMessage(
-                        "An error occurred and we couldn't complete the request. Please try again later.",
+                        "Members couldn't be added from the backup file. The alias may be invalid or there might be a problem connecting to the server. Please try again later.",
                         "Hummingbird",
                         MessageBoxButton.OK);
                 }

--- a/src/Pages/BulkAddMain.xaml.cs
+++ b/src/Pages/BulkAddMain.xaml.cs
@@ -78,7 +78,7 @@ namespace Hummingbird.Pages
                     int invalidMemberCount = membersAdded.Where(r => r.InvalidMembers != null).Sum(r => r.InvalidMembers.Count);
                     int successfulMembersCount = totalMembersCount - (invalidMemberCount + failedMemberCount);
 
-                    if (!membersAdded.Any(x => x.StatusCode.ToLower() != "noerror"))
+                    if (membersAdded.All(x => x.StatusCode.ToLower() == "noerror"))
                     {
                         string message = string.Format("Bulk add complete! Added {0} members.", totalMembersCount);
 
@@ -117,9 +117,11 @@ namespace Hummingbird.Pages
                             MessageBoxButton.OK);
 
                         var fsOperator = new FileSystemOperator();
-                        AddMembersErrorDetails error = new AddMembersErrorDetails();
-                        error.FailedMembers = new List<string>();
-                        error.InvalidMembers = new List<string>();
+                        AddMembersErrorDetails error = new AddMembersErrorDetails
+                        {
+                            FailedMembers = new List<string>(),
+                            InvalidMembers = new List<string>()
+                        };
                         foreach (var list in membersAdded)
                         {
                             if (list.FailedMembers != null) { error.FailedMembers.AddRange(list.FailedMembers); }
@@ -224,7 +226,7 @@ namespace Hummingbird.Pages
 
                     var gugResults = await GetGroupInformation(credentials, TxtBackupGroupBox.Text);
 
-                    GetUnifiedGroupEnvelope gugEnvelope = (GetUnifiedGroupEnvelope)gugResults;
+                    GetUnifiedGroupEnvelope gugEnvelope = (GetUnifiedGroupEnvelope) gugResults;
 
                     GroupSimplifier simplifier = new GroupSimplifier();
                     var dl =
@@ -292,7 +294,7 @@ namespace Hummingbird.Pages
                     AccountSettingsViewModel.Instance.ServerUrl, groupQualifiedName, ExchangeRequestType.GetUnifiedGroupDetails);
             });
 
-            return (GetUnifiedGroupEnvelope)result;
+            return (GetUnifiedGroupEnvelope) result;
         }
 
         private class BulkAddMembersResult

--- a/src/Pages/DLGroupMigrationMain.xaml.cs
+++ b/src/Pages/DLGroupMigrationMain.xaml.cs
@@ -203,7 +203,7 @@ namespace Hummingbird.Pages
 
                                 if (!string.IsNullOrWhiteSpace(groupCreated))
                                 {
-                                    ModernDialog.ShowMessage("Group creation complete!", "Hummingbird",
+                                    ModernDialog.ShowMessage(string.Format("Your group has been created successfully. SMTP: {0}", groupCreated), "Hummingbird",
                                         MessageBoxButton.OK);
                                 }
 
@@ -272,7 +272,7 @@ namespace Hummingbird.Pages
                             {
                                 if (invalidMembers.Count == 0)
                                 {
-                                    ModernDialog.ShowMessage("Your group has been created successfully.", "Hummingbird",
+                                    ModernDialog.ShowMessage(string.Format("Your group has been created successfully. SMTP: {0}.", groupCreated), "Hummingbird",
                                                 MessageBoxButton.OK);
                                 }
                                 else

--- a/src/Pages/DLGroupMigrationMain.xaml.cs
+++ b/src/Pages/DLGroupMigrationMain.xaml.cs
@@ -104,7 +104,7 @@ namespace Hummingbird.Pages
                     {
                         var result =
                             ModernDialog.ShowMessage(
-                                "The alias provided does not map to a valid DL.",
+                                "The alias you provided doesn't map to a valid DL.",
                                 "Hummingbird", MessageBoxButton.OK);
                         resolveMembers = false;
                     }
@@ -112,7 +112,7 @@ namespace Hummingbird.Pages
                     {
                         var result =
                             ModernDialog.ShowMessage(
-                                "The group owner could not be found. Would you like to attempt to retrieve members anyway? The backup will be missing the Owner property.",
+                                "The group owner couldn't be found. If you attempt to retrieve members for the group, the backup will be missing the Owner property. Continue?",
                                 "Hummingbird", MessageBoxButton.YesNo);
                         resolveMembers = result == MessageBoxResult.Yes;
                     }
@@ -135,7 +135,7 @@ namespace Hummingbird.Pages
                             {
                                 var result =
                                     ModernDialog.ShowMessage(
-                                        "Distribution list backup created. Open Windows Explorer for its location?",
+                                        "A backup was created for the distribution list. Do you want to open File Explorer to find its location?",
                                         "Hummingbird", MessageBoxButton.YesNo);
 
                                 if (result == MessageBoxResult.Yes)
@@ -146,14 +146,14 @@ namespace Hummingbird.Pages
                             else
                             {
                                 ModernDialog.ShowMessage(
-                                    "We couldn't create the backup file for this distribution list.", "Hummingbird",
+                                    "We couldn't create a backup file for this distribution list. Please try again.", "Hummingbird",
                                     MessageBoxButton.OK);
                             }
                         }
                         else
                         {
                             ModernDialog.ShowMessage(
-                                "We couldn't get distribution list members. Check your credentials.", "Hummingbird",
+                                "We couldn't retrieve members of the distribution list. Check your credentials and try again.", "Hummingbird",
                                 MessageBoxButton.OK);
                         }
                     }
@@ -165,13 +165,13 @@ namespace Hummingbird.Pages
                 else
                 {
                     ModernDialog.ShowMessage(
-                        "There are no user credentials provided. Open SETTINGS and add your credentials.", "Hummingbird",
+                        "No credentials were provided. Open Settings and add your credentials.", "Hummingbird",
                         MessageBoxButton.OK);
                 }
             }
             else
             {
-                ModernDialog.ShowMessage("Alias cannot be empty!", "Hummingbird", MessageBoxButton.OK);
+                ModernDialog.ShowMessage("You must include an alias.", "Hummingbird", MessageBoxButton.OK);
             }
         }
 
@@ -203,7 +203,7 @@ namespace Hummingbird.Pages
 
                                 if (!string.IsNullOrWhiteSpace(groupCreated))
                                 {
-                                    ModernDialog.ShowMessage(string.Format("Your group has been created successfully. SMTP: {0}", groupCreated), "Hummingbird",
+                                    ModernDialog.ShowMessage(string.Format("Your group was created successfully. SMTP address: {0}", groupCreated), "Hummingbird",
                                         MessageBoxButton.OK);
                                 }
 
@@ -224,7 +224,7 @@ namespace Hummingbird.Pages
                             if (string.IsNullOrEmpty(groupCreated))
                             {
                                 operationFailed = true;
-                                ModernDialog.ShowMessage(string.Format("Group could not be created, please try migration after sometime."), "Hummingbird",
+                                ModernDialog.ShowMessage(string.Format("The group couldn't be created. Please try migrating again later."), "Hummingbird",
                                                 MessageBoxButton.OK);
                             }
                             else
@@ -261,7 +261,7 @@ namespace Hummingbird.Pages
 
                                     if (operationFailed)
                                     {
-                                        ModernDialog.ShowMessage(string.Format("Your group was created, but all the members were not added. Please go to “bulk add” to add the members using original backup and following group address {0}", groupCreated), "Hummingbird",
+                                        ModernDialog.ShowMessage(string.Format(@"The group was created, but not all the members were added. Please go to 'bulk add' to add the missing members using the original backup and the following group address {0}.", groupCreated), "Hummingbird",
                                             MessageBoxButton.OK);
                                         break;
                                     }
@@ -272,12 +272,12 @@ namespace Hummingbird.Pages
                             {
                                 if (invalidMembers.Count == 0)
                                 {
-                                    ModernDialog.ShowMessage(string.Format("Your group has been created successfully. SMTP: {0}.", groupCreated), "Hummingbird",
+                                    ModernDialog.ShowMessage(string.Format("Your group was created successfully. SMTP address: {0}.", groupCreated), "Hummingbird",
                                                 MessageBoxButton.OK);
                                 }
                                 else
                                 {
-                                    ModernDialog.ShowMessage("Your group has been created. Invalid members were not added.", "Hummingbird",
+                                    ModernDialog.ShowMessage("The group was created but invalid members weren't added.", "Hummingbird",
                                                 MessageBoxButton.OK);
 
                                     var fsOperator = new FileSystemOperator();
@@ -289,7 +289,7 @@ namespace Hummingbird.Pages
                                     {
                                         var result =
                                             ModernDialog.ShowMessage(
-                                                "The invalid members list is created. Open Windows Explorer for its location?",
+                                                "The list of invalid members was created. Do you want to open File Explorer to find its location?",
                                                 "Hummingbird", MessageBoxButton.YesNo);
 
                                         if (result == MessageBoxResult.Yes)
@@ -306,19 +306,20 @@ namespace Hummingbird.Pages
                     }
                     else
                     {
-                        ModernDialog.ShowMessage("Looks like you don't have any credentials associated.", "Hummingbird",
+                        ModernDialog.ShowMessage("No credentials were provided. Open Settings and add your credentials.", "Hummingbird",
                             MessageBoxButton.OK);
                     }
                 }
                 else
                 {
-                    ModernDialog.ShowMessage("Looks like an invalid alias or we can't reach the server at this time.",
-                        "Hummingbird", MessageBoxButton.OK);
+                    ModernDialog.ShowMessage("The group couldn't be created from the backup file. The alias may be invalid or there might be a problem connecting to the server. Please try again later.",
+                        "Hummingbird",
+                         MessageBoxButton.OK);
                 }
             }
             else
             {
-                ModernDialog.ShowMessage("Alias cannot be empty!", "Hummingbird", MessageBoxButton.OK);
+                ModernDialog.ShowMessage("You must include an alias.", "Hummingbird", MessageBoxButton.OK);
             }
 
             DlGroupMigrationViewModel.Instance.CurrentlyActiveDl = null;

--- a/src/Pages/DLGroupMigrationMain.xaml.cs
+++ b/src/Pages/DLGroupMigrationMain.xaml.cs
@@ -33,7 +33,7 @@ namespace Hummingbird.Pages
         {
             InitializeComponent();
 
-            _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+            _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1)};
             _timer.Tick += _timer_Tick;
         }
 
@@ -81,7 +81,7 @@ namespace Hummingbird.Pages
                     TxtBackupStatus.Text = "trying to identify alias...";
 
                     var adConnector = new ActiveDirectoryConnector();
-                    var dl = new DistributionList { Name = TxtDlAlias.Text };
+                    var dl = new DistributionList {Name = TxtDlAlias.Text};
                     var owner = string.Empty;
                     bool isValidDl;
                     if (!AccountSettingsViewModel.Instance.IsInternal)
@@ -386,7 +386,7 @@ namespace Hummingbird.Pages
                     AccountSettingsViewModel.Instance.ServerUrl, alias, ExchangeRequestType.ValidateAlias);
             });
 
-            return result != null && ((AliasValidationEnvelope)result).Body.Response.IsAliasUnique;
+            return result != null && ((AliasValidationEnvelope) result).Body.Response.IsAliasUnique;
         }
 
         private void BtnViewMembers_OnClick(object sender, RoutedEventArgs e)
@@ -397,7 +397,7 @@ namespace Hummingbird.Pages
 
         private void BtnOpenDlFile_OnClick(object sender, RoutedEventArgs e)
         {
-            var openFileDialog = new OpenFileDialog { Filter = "XML DL Files (*.xmldl) | *.xmldl" };
+            var openFileDialog = new OpenFileDialog { Filter = "XML DL Files (*.xmldl) | *.xmldl"};
             var result = openFileDialog.ShowDialog();
 
             if (result != true) return;

--- a/src/Resources/group_create.xml
+++ b/src/Resources/group_create.xml
@@ -20,7 +20,7 @@
         <ReportToOriginatorEnabled>false</ReportToOriginatorEnabled>
         <SubscriptionEnabled>true</SubscriptionEnabled>
         <WarmupEmailEnabled>true</WarmupEmailEnabled>
-        <WelcomeMessageEnabled>false</WelcomeMessageEnabled>
+        <WelcomeMessageEnabled>true</WelcomeMessageEnabled>
       </ExchangeProvisioningOptions>
     </CreateUnifiedGroup>
   </s:Body>

--- a/src/Resources/group_create.xml
+++ b/src/Resources/group_create.xml
@@ -20,7 +20,7 @@
         <ReportToOriginatorEnabled>false</ReportToOriginatorEnabled>
         <SubscriptionEnabled>true</SubscriptionEnabled>
         <WarmupEmailEnabled>true</WarmupEmailEnabled>
-        <WelcomeMessageEnabled>true</WelcomeMessageEnabled>
+        <WelcomeMessageEnabled>false</WelcomeMessageEnabled>
       </ExchangeProvisioningOptions>
     </CreateUnifiedGroup>
   </s:Body>

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,7 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
   <package id="EnterpriseLibrary.Common" version="6.0.1304.0" targetFramework="net45" />
   <package id="EnterpriseLibrary.Logging" version="6.0.1304.0" targetFramework="net45" />
   <package id="Microsoft.Exchange.WebServices" version="2.2" targetFramework="net45" />
-  <package id="ModernUI.WPF" version="1.0.6" targetFramework="net45" />
+  <package id="ModernUI.WPF" version="1.0.9" targetFramework="net45" />
+  <package id="Unity" version="4.0.1" targetFramework="net45" />
+  <package id="Unity.Interception" version="4.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Changes:

```
 1) Support Create On Behalf of for Group: To help tenant admins migrate Dls owned by other users in their Organization.
 2) Batching add members call to support migration of large Dls. (225 per call) 
 3) Improving the error messaging.
 4) Use custom configurations for group like do not send Welcome email and subscribe all members by default. 
```
